### PR TITLE
Parquet Modular Encryption for appending/scanning data to/from pyarrow FileIO.

### DIFF
--- a/pyiceberg/io/__init__.py
+++ b/pyiceberg/io/__init__.py
@@ -93,8 +93,8 @@ GCS_SERVICE_HOST = "gcs.service.host"
 GCS_DEFAULT_LOCATION = "gcs.default-bucket-location"
 GCS_VERSION_AWARE = "gcs.version-aware"
 PYARROW_USE_LARGE_TYPES_ON_READ = "pyarrow.use-large-types-on-read"
-COLUMN_KEY="table.column-key"
-FOOTER_KEY="table.footer-key"
+COLUMN_KEY = "table.column-key"
+FOOTER_KEY = "table.footer-key"
 
 @runtime_checkable
 class InputStream(Protocol):

--- a/pyiceberg/io/__init__.py
+++ b/pyiceberg/io/__init__.py
@@ -93,7 +93,8 @@ GCS_SERVICE_HOST = "gcs.service.host"
 GCS_DEFAULT_LOCATION = "gcs.default-bucket-location"
 GCS_VERSION_AWARE = "gcs.version-aware"
 PYARROW_USE_LARGE_TYPES_ON_READ = "pyarrow.use-large-types-on-read"
-
+COLUMN_KEY="table.column-key"
+FOOTER_KEY="table.footer-key"
 
 @runtime_checkable
 class InputStream(Protocol):


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
-->

<!-- In the case this PR will resolve an issue, please replace ${GITHUB_ISSUE_ID} below with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->

# Rationale for this change
The current version of iceberg-python doesn't have Parquet Modular Encryption (PME) implemented. As a result, the parquet files are written in clear. This change has addressed this limitation by adding PME for appending/scanning data to/from pyarrow FileIO.

# Are these changes tested?
Yes. These changes are tested locally. PME is working as expected.

# Are there any user-facing changes?
Yes. While creating a PyIceberg table using catalog's create_table method, user needs to add following 2 properties to specify which AWS KMS Key to use:
&nbsp;&nbsp;&nbsp;&nbsp;table.column-key
&nbsp;&nbsp;&nbsp;&nbsp;table.footer-key
For example:
pyiceberg_table = sample_catalog.create_table(
&nbsp;&nbsp;&nbsp;&nbsp;identifier="default.identifier",
&nbsp;&nbsp;&nbsp;&nbsp;properties={
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"table.column-key": {"aws_kms_key_id1": ["sample_column"]}, 
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"table.footer-key": "aws_kms_key_id2", 
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"write.parquet.compression-level": 22
&nbsp;&nbsp;&nbsp;&nbsp;}, 
&nbsp;&nbsp;&nbsp;&nbsp;schema=pyarrow_table.schema
)

<!-- In the case of user-facing changes, please add the changelog label. -->
